### PR TITLE
fix: fix error handling and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ make build
 make test
 make install
 
-consumerd -listen-addr="" -grpc-addr="" -data-dir=""
+consumerd -listen-addr="" -panacea-grpc-addr="" -data-dir=""
 # ex) consumerd -listen-addr="127.0.0.1:8080" -grpc-addr="http://127.0.0.1:9090"
-# The `-grpc-addr` value should be with URL scheme such as `http`, `https`.
-# The `data-dir` value is the path which the data will be stored.
+# The `-panacea-grpc-addr` value should be with URL scheme such as `http`, `https`, and `tcp`.
+# The `-data-dir` value is the path which the data will be stored.
 ```
 
 ## Request Store a Data

--- a/cmd/consumerd/main.go
+++ b/cmd/consumerd/main.go
@@ -6,12 +6,13 @@ import (
 	"os"
 
 	"github.com/medibloc/panacea-dep-consumer/server"
+	log "github.com/sirupsen/logrus"
 )
 
 func main() {
 	httpPtr := flag.String("listen-addr", "", "http server listen address")
-	grpcPtr := flag.String("grpc-addr", "", "grpc server listen address")
-	dataDirPtr := flag.String("data-dir", "", "the directory which data will be stored")
+	grpcPtr := flag.String("panacea-grpc-addr", "", "panacea grpc server listen address")
+	dataDirPtr := flag.String("data-dir", "", "the path which data will be stored")
 	flag.Parse()
 
 	if *httpPtr == "" || *grpcPtr == "" || *dataDirPtr == "" {
@@ -21,6 +22,7 @@ func main() {
 	}
 
 	if err := server.Run(*httpPtr, *grpcPtr, *dataDirPtr); err != nil {
+		log.Errorf("failed to start consumer service: %v", err)
 		os.Exit(1)
 	}
 

--- a/panacea/grpc_client.go
+++ b/panacea/grpc_client.go
@@ -36,8 +36,10 @@ func NewGRPCClient(grpcAddr string) (GRPCClient, error) {
 
 	if parsedUrl.Scheme == "https" {
 		cred = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
-	} else {
+	} else if parsedUrl.Scheme == "http" || parsedUrl.Scheme == "tcp" {
 		cred = grpc.WithInsecure()
+	} else {
+		return nil, fmt.Errorf("invalid URL scheme: %s", parsedUrl.Scheme)
 	}
 
 	conn, err := grpc.Dial(parsedUrl.Host, cred)


### PR DESCRIPTION
- Show an error message when starting the server.
- Return an error when parsed URL scheme is not `http`, `https`, or `tcp`.
- Update `README.md`.